### PR TITLE
Fix missing components

### DIFF
--- a/src/fhirpatch.js
+++ b/src/fhirpatch.js
@@ -62,7 +62,11 @@ module.exports = class FhirPatch {
     const fmt = resourceFormat(resource);
     let rsc = normalizeResource(resource);
     for (const op of this._operations) {
-      rsc = op.apply(rsc);
+      try {
+        rsc = op.apply(rsc);
+      } catch (error) {
+        console.log(error);
+      }
     }
 
     rsc=cleanupResource(rsc);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -157,6 +157,13 @@ function processValue(value) {
     return value.valueCodeableConcept;
   }
 
+  if (value.valueContactPoint) {
+    if (!_.isObject(value.valueContactPoint)) {
+      throw new Error(`Invalid value for type valueContactPoint: ${value.valueContactPoint}`);
+    }
+    return value.valueContactPoint;
+  }
+
   if (value.valueCode) {
     if (!_.isString(value.valueCode)) {
       throw new Error(`Invalid value for type valueCode: ${value.valueCode}`);

--- a/src/operation.js
+++ b/src/operation.js
@@ -34,7 +34,6 @@ module.exports = class Operation {
    */
   apply(resource) {
     let res;
-
     switch (this.type) {
       case 'add':
         res = fp.evaluate(resource, this.path);
@@ -62,13 +61,17 @@ module.exports = class Operation {
         }
         break;
       case 'insert':
-        res = fp.evaluate(resource, this.containingPath);
+        res = fp.evaluate(resource, this.path);
         if (res.length == 0) {
           throw new PathNotFoundError(
-              `Nothing to modify at path ${this.containingPath}`);
+              `Nothing to modify at path ${this.path}`);
         }
 
-        res[0][this.tail.path].splice(this.index, 0, this.value);
+        res.unshift(this.value);
+        const path = this.path.split('.');
+        path.shift();
+
+        _.set(resource, path.join('.'), res);
         break;
       case 'move':
         res = fp.evaluate(resource, this.containingPath);


### PR DESCRIPTION
- When going through the operations if the path didn't exist for one of the resources in one of the context it would throw an error and not apply anything. This.containingPath strips off the last item and ends up not applying it
- the valueContactPoint was missing from the helper
- insert should always add to the front

The tests currently do not pass but I want to put this out there as I had to make these changes to get things working. We should talk about the tests, and the expectation of inserts.